### PR TITLE
Remove explicit sleep and handle connection timeout during wake sequence

### DIFF
--- a/lib/atecc508a/transport/i2c_server.ex
+++ b/lib/atecc508a/transport/i2c_server.ex
@@ -12,6 +12,7 @@ defmodule ATECC508A.Transport.I2CServer do
   @atecc508a_poll_interval_ms 2
   @atecc508a_retry_wakeup_ms 500
   @atecc508a_default_wakeup_retries 4
+  @atecc508a_wake <<0>>
 
   @spec start_link(keyword()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link([bus_name, address, process_name]) do
@@ -48,25 +49,13 @@ defmodule ATECC508A.Transport.I2CServer do
     {:ok, i2c} = Circuits.I2C.open(bus_name)
 
     state = %{i2c: i2c, bus_name: bus_name, address: address, cache: Cache.init()}
-    {:ok, state, {:continue, :start_asleep}}
-  end
-
-  @impl true
-  def handle_continue(:start_asleep, state) do
-    # Issue a sleep command so that the device starts out in the sleep
-    # state even if some other code wakes it up. If this isn't done, we'll
-    # get out of sync with the sleep/wake state and end up getting confused
-    # when we don't get the expected wake response.
-    _ = sleep(state.i2c, state.address)
-
-    {:noreply, state}
+    {:ok, state}
   end
 
   @impl true
   def handle_call(:detected?, _from, state) do
     case wakeup(state.i2c, state.address) do
       :ok ->
-        _ = sleep(state.i2c, state.address)
         {:reply, true, state}
 
       _ ->
@@ -147,10 +136,6 @@ defmodule ATECC508A.Transport.I2CServer do
           error
       end
 
-    # Always send a sleep after a request even if it fails so that the processor is in
-    # a known state for the next call.
-    _ = sleep(state.i2c, state.address)
-
     rc
   end
 
@@ -166,6 +151,29 @@ defmodule ATECC508A.Transport.I2CServer do
     end
   end
 
+  defp validate_signature_or_retry({:ok, @atecc508a_signature}, _retries) do
+    :ok
+  end
+
+  defp validate_signature_or_retry({:ok, something_else}, retries) do
+    Logger.warn(
+      "Unexpected wakeup response: #{inspect(something_else)}. #{retries - 1} retries remaining."
+    )
+
+    {:retry, retries - 1}
+  end
+
+  defp validate_signature_or_retry({:error, :"Connection timed out"}, retries) do
+    Logger.warn("Connection timed out. #{retries - 1} retries remaining.")
+
+    {:retry, retries - 1}
+  end
+
+  defp validate_signature_or_retry(error, _retries) do
+    Logger.error("Unexpected error response: #{inspect(error)}. ")
+    error
+  end
+
   defp wakeup(i2c, address, retries \\ @atecc508a_default_wakeup_retries)
 
   defp wakeup(_i2c, _address, 0) do
@@ -179,33 +187,24 @@ defmodule ATECC508A.Transport.I2CServer do
     # Since only 8-bits get through, the I2C speed needs to be < 133 KHz for
     # this to work. This "fails" since nobody will ACK the write and that's
     # expected.
-    _ = Circuits.I2C.write(i2c, 0, <<0>>)
+    _ = Circuits.I2C.write(i2c, 0, @atecc508a_wake)
 
     # Wait for the device to wake up for real
     Process.sleep(@atecc508a_wake_delay_ms)
 
     # Check that it's awake by reading its signature
-    case Circuits.I2C.read(i2c, address, 4) do
-      {:ok, @atecc508a_signature} ->
+    case Circuits.I2C.read(i2c, address, 4)
+         |> validate_signature_or_retry(retries) do
+      :ok ->
         :ok
 
-      {:ok, something_else} ->
-        Logger.warn(
-          "Unexpected wakeup response: #{inspect(something_else)}. #{retries - 1} retries remaining."
-        )
-
+      {:retry, remaining} ->
         Process.sleep(@atecc508a_retry_wakeup_ms)
-        _ = sleep(i2c, address)
-        wakeup(i2c, address, retries - 1)
+        wakeup(i2c, address, remaining)
 
       error ->
         error
     end
-  end
-
-  defp sleep(i2c, address) do
-    # See ATECC508A 6.2 for the sleep sequence.
-    Circuits.I2C.write(i2c, address, <<0x01>>)
   end
 
   defp poll_read(i2c, address, response_len, timeout, max_timeout) do


### PR DESCRIPTION
@IvoBCD Please review

The changes can be explained as follows:

1. Remove explicit calls to put atecc508a to sleep between steps. This should not be needed since the wake sequence is sending "<<0>>" , delaying for 2ms and reading 4 bytes. 
2. Handling "Connection timed out" error during wake up sequence

I did not change any of the timing parameters and have not seen any issues so far. The biggest change is the sleep handling which may need to be reworked before an upstream merge.